### PR TITLE
update deps

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,18 +18,16 @@
     "@acala-network/type-definitions": "4.1.2-8",
     "@babel/runtime": "^7.10.2",
     "@open-web3/api-mobx": "^1.0.2-4",
-    "@open-web3/orml-types": "^1.0.2-4",
-    "@polkadot/api": "^7.1.1",
-    "@polkadot/typegen": "^7.1.1",
-    "@polkadot/types": "^7.1.1"
+    "@open-web3/orml-types": "^1.0.2-4"
   },
   "devDependencies": {
+    "@polkadot/api": "^7.1.1",
+    "@polkadot/typegen": "^7.1.1",
+    "@polkadot/types": "^7.1.1",
     "@types/websocket": "^1.0.0",
     "websocket": "^1.0.31"
   },
   "peerDependencies": {
-    "@polkadot/api": "^7.1.1",
-    "@polkadot/typegen": "^7.1.1",
-    "@polkadot/types": "^7.1.1"
+    "@polkadot/api": ">7.1.1"
   }
 }

--- a/packages/types/src/interfaces/accounts/definitions.ts
+++ b/packages/types/src/interfaces/accounts/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import accounts from '@acala-network/type-definitions/accounts';
 
 export default accounts as Definitions;

--- a/packages/types/src/interfaces/auctionManager/definitions.ts
+++ b/packages/types/src/interfaces/auctionManager/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import auctionManager from '@acala-network/type-definitions/auctionManager';
 
 export default auctionManager as Definitions;

--- a/packages/types/src/interfaces/cdpEngine/definitions.ts
+++ b/packages/types/src/interfaces/cdpEngine/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import cdpEngine from '@acala-network/type-definitions/cdpEngine';
 
 export default cdpEngine as Definitions;

--- a/packages/types/src/interfaces/collatorSelection/definitions.ts
+++ b/packages/types/src/interfaces/collatorSelection/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import collatorSelection from '@acala-network/type-definitions/collatorSelection';
 
 export default collatorSelection as Definitions;

--- a/packages/types/src/interfaces/dex/definitions.ts
+++ b/packages/types/src/interfaces/dex/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import dex from '@acala-network/type-definitions/dex';
 
 export default dex as Definitions;

--- a/packages/types/src/interfaces/evm/definitions.ts
+++ b/packages/types/src/interfaces/evm/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import evm from '@acala-network/type-definitions/evm';
 
 export default evm as Definitions;

--- a/packages/types/src/interfaces/homa/definitions.ts
+++ b/packages/types/src/interfaces/homa/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import homa from '@acala-network/type-definitions/homa';
 
 export default homa as Definitions;

--- a/packages/types/src/interfaces/homaValidatorList/definitions.ts
+++ b/packages/types/src/interfaces/homaValidatorList/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import homaValidatorList from '@acala-network/type-definitions/homaValidatorList';
 
 export default homaValidatorList as Definitions;

--- a/packages/types/src/interfaces/incentives/definitions.ts
+++ b/packages/types/src/interfaces/incentives/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import incentives from '@acala-network/type-definitions/incentives';
 
 export default incentives as Definitions;

--- a/packages/types/src/interfaces/loans/definitions.ts
+++ b/packages/types/src/interfaces/loans/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import loans from '@acala-network/type-definitions/loans';
 
 export default loans as Definitions;

--- a/packages/types/src/interfaces/nft/definitions.ts
+++ b/packages/types/src/interfaces/nft/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import nft from '@acala-network/type-definitions/nft';
 
 export default nft as Definitions;

--- a/packages/types/src/interfaces/nomineesElection/definitions.ts
+++ b/packages/types/src/interfaces/nomineesElection/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import nomineesElection from '@acala-network/type-definitions/nomineesElection';
 
 export default nomineesElection as Definitions;

--- a/packages/types/src/interfaces/primitives/definitions.ts
+++ b/packages/types/src/interfaces/primitives/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import primitives from '@acala-network/type-definitions/primitives';
 
 export default primitives as Definitions;

--- a/packages/types/src/interfaces/renvmBridge/definitions.ts
+++ b/packages/types/src/interfaces/renvmBridge/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import renvmBridge from '@acala-network/type-definitions/renvmBridge';
 
 export default renvmBridge as Definitions;

--- a/packages/types/src/interfaces/runtime/definitions.ts
+++ b/packages/types/src/interfaces/runtime/definitions.ts
@@ -1,5 +1,5 @@
 import definitions from '@polkadot/types/interfaces/runtime/definitions';
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import runtime from '@acala-network/type-definitions/runtime';
 
 export default {

--- a/packages/types/src/interfaces/stakingPool/definitions.ts
+++ b/packages/types/src/interfaces/stakingPool/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import stakingPool from '@acala-network/type-definitions/stakingPool';
 
 export default stakingPool as Definitions;

--- a/packages/types/src/interfaces/support/definitions.ts
+++ b/packages/types/src/interfaces/support/definitions.ts
@@ -1,4 +1,4 @@
-import { Definitions } from '@polkadot/types/types';
+import type { Definitions } from '@polkadot/types/types';
 import support from '@acala-network/type-definitions/support';
 
 export default support as Definitions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,9 +279,7 @@ __metadata:
     "@types/websocket": ^1.0.0
     websocket: ^1.0.31
   peerDependencies:
-    "@polkadot/api": ^7.1.1
-    "@polkadot/typegen": ^7.1.1
-    "@polkadot/types": ^7.1.1
+    "@polkadot/api": ">7.1.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Avoid direct dependencies on polkadot.js, which can cause confusion about the version of polkadot.js for libraries that depend on our library.