### PR TITLE
update runtime and missing types

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/AcalaNetwork/acala.js",
   "dependencies": {
     "@acala-network/api-derive": "4.1.8-1",
-    "@acala-network/types": "~4.1.8-2.2",
+    "@acala-network/types": "4.1.8-2.2",
     "@babel/runtime": "^7.10.2",
     "@open-web3/orml-api-derive": "^1.1.4",
     "@polkadot/api": "^9.9.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/AcalaNetwork/acala.js",
   "dependencies": {
     "@acala-network/api-derive": "4.1.8-1",
-    "@acala-network/types": "4.1.8-1",
+    "@acala-network/types": "~4.1.8-2.2",
     "@babel/runtime": "^7.10.2",
     "@open-web3/orml-api-derive": "^1.1.4",
     "@polkadot/api": "^9.9.1",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,7 +5,7 @@ import {
   typesAlias as acalaTypesAlias,
   typesBundle as acalaTypesBundle,
   signedExtensions as acalaSignedExtensions,
-  lookupType as acalaLookupTypes,
+  lookupTypes as acalaLookupTypes
 } from '@acala-network/types';
 import { ApiOptions } from '@polkadot/api/types';
 import { RegistryTypes } from '@polkadot/types/types';
@@ -26,7 +26,7 @@ export const options = ({
 }: ApiOptions = {}): ApiOptions => ({
   types: {
     ...acalaTypes,
-    ...(acalaLookupTypes as unknown as RegistryTypes),  // TODO: RegistryTypes's own issue?
+    ...(acalaLookupTypes as unknown as RegistryTypes), // TODO: RegistryTypes's own issue?
     ...types
   },
   rpc: {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -4,9 +4,12 @@ import {
   types as acalaTypes,
   typesAlias as acalaTypesAlias,
   typesBundle as acalaTypesBundle,
-  signedExtensions as acalaSignedExtensions
+  signedExtensions as acalaSignedExtensions,
+  lookupType as acalaLookupTypes,
 } from '@acala-network/types';
 import { ApiOptions } from '@polkadot/api/types';
+import { RegistryTypes } from '@polkadot/types/types';
+import { runtime } from './runtime';
 
 export const defaultOptions: ApiOptions = {
   types: acalaTypes,
@@ -22,6 +25,8 @@ export const options = ({
   ...otherOptions
 }: ApiOptions = {}): ApiOptions => ({
   types: {
+    ...acalaTypes,
+    ...(acalaLookupTypes as unknown as RegistryTypes),  // TODO: RegistryTypes's own issue?
     ...types
   },
   rpc: {
@@ -58,5 +63,6 @@ export const options = ({
     ...acalaSignedExtensions,
     ...signedExtensions
   },
+  runtime,
   ...otherOptions
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -66,7 +66,7 @@ export const options = ({
   },
   runtime: {
     ...acalaRuntime,
-    ...runtime,
+    ...runtime
   },
   ...otherOptions
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from '@acala-network/types';
 import { ApiOptions } from '@polkadot/api/types';
 import { RegistryTypes } from '@polkadot/types/types';
-import { runtime } from './runtime';
+import { runtime as acalaRuntime } from './runtime';
 
 export const defaultOptions: ApiOptions = {
   types: acalaTypes,
@@ -21,6 +21,7 @@ export const options = ({
   rpc = {},
   typesAlias = {},
   typesBundle = {},
+  runtime = {},
   signedExtensions,
   ...otherOptions
 }: ApiOptions = {}): ApiOptions => ({
@@ -63,6 +64,9 @@ export const options = ({
     ...acalaSignedExtensions,
     ...signedExtensions
   },
-  runtime,
+  runtime: {
+    ...acalaRuntime,
+    ...runtime,
+  },
   ...otherOptions
 });

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -1,0 +1,49 @@
+import { ApiOptions } from "@polkadot/api/types";
+
+export const runtime: ApiOptions['runtime'] = {
+  EVMRuntimeRPCApi: [
+    {
+      version: 2,
+      methods: {
+        call: {
+          description: 'call evm',
+          params: [
+            {
+              name: 'from',
+              type: 'H160'
+            },
+            {
+              name: 'to',
+              type: 'H160'
+            },
+            {
+              name: 'data',
+              type: 'Vec<u8>'
+            },
+            {
+              name: 'value',
+              type: 'Balance'
+            },
+            {
+              name: 'gas_limit',
+              type: 'u64'
+            },
+            {
+              name: 'storage_limit',
+              type: 'u32'
+            },
+            {
+              name: 'access_list',
+              type: 'Option<Vec<EthereumTransactionAccessListItem>>'
+            },
+            {
+              name: 'estimate',
+              type: 'bool'
+            }
+          ],
+          type: 'Result<CallInfo, sp_runtime::DispatchError>'
+        }
+      }
+    }
+  ]
+};

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -1,4 +1,4 @@
-import { ApiOptions } from "@polkadot/api/types";
+import { ApiOptions } from '@polkadot/api/types';
 
 export const runtime: ApiOptions['runtime'] = {
   EVMRuntimeRPCApi: [

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from '@polkadot/types/types';
 
 import './interfaces/augment-api';
+import './interfaces/augment-types';
 
 export * as lookupTypes from './interfaces/lookup';
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,9 +13,9 @@ import {
   DefinitionRpcSub
 } from '@polkadot/types/types';
 
-export * as lookupType from './interfaces/lookup';
-
 import './interfaces/augment-api';
+
+export * as lookupTypes from './interfaces/lookup';
 
 // export * from './interfaces/augment-api-mobx';
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,11 +13,9 @@ import {
   DefinitionRpcSub
 } from '@polkadot/types/types';
 
-import './interfaces/augment-api-consts';
-import './interfaces/augment-api-query';
-import './interfaces/augment-api-rpc';
-import './interfaces/augment-api-tx';
-import './interfaces/augment-types';
+export * as lookupType from './interfaces/lookup';
+
+import './interfaces/augment-api';
 
 // export * from './interfaces/augment-api-mobx';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,7 +33,7 @@ __metadata:
   resolution: "@acala-network/api@workspace:packages/api"
   dependencies:
     "@acala-network/api-derive": 4.1.8-1
-    "@acala-network/types": 4.1.8-1
+    "@acala-network/types": 4.1.8-2.2
     "@babel/runtime": ^7.10.2
     "@open-web3/orml-api-derive": ^1.1.4
     "@polkadot/api": ^9.9.1
@@ -391,6 +391,20 @@ __metadata:
   peerDependencies:
     "@polkadot/api": ">8.5.1"
   checksum: dcf662bf8bff7c9c0e77155ebec8b251494befe8a09d4a0cd48272d3e912d40884429b3dd1af8fc75ecf42bea0655433986999fd6a60c1372c34d706ec4e9404
+  languageName: node
+  linkType: hard
+
+"@acala-network/types@npm:4.1.8-2.2":
+  version: 4.1.8-2.2
+  resolution: "@acala-network/types@npm:4.1.8-2.2"
+  dependencies:
+    "@acala-network/type-definitions": 4.1.8-1
+    "@babel/runtime": ^7.10.2
+    "@open-web3/api-mobx": ^1.1.4
+    "@open-web3/orml-types": ^1.1.4
+  peerDependencies:
+    "@polkadot/api": ">=8"
+  checksum: 17bd732473df44a16202c1c10afc31f647764a10d21f118e19444ee084deb5b47e585cae11af17847b9894ee3cb5762e7626b897a0ddaa1e0bdd45eb507bcf11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Change
- looks like previously `acalaTypes` and `lookupTypes` are missing in types when using `options()` to generate apiOptions, so added it
- also added the runtime definitions (which didn't seem to get generated automatically) for using `state_call`

## Test
tested with local build and can found the desired types