### PR TITLE
fix esm error

### DIFF
--- a/packages/sdk-core/src/converter.ts
+++ b/packages/sdk-core/src/converter.ts
@@ -1,5 +1,5 @@
 import { AcalaPrimitivesCurrencyCurrencyId, AcalaPrimitivesCurrencyTokenSymbol } from '@polkadot/types/lookup';
-import { isArray } from 'lodash';
+import isArray from 'lodash/isArray.js';
 import {
   ConvertToCurrencyIdFailed,
   ConvertToCurrencyNameFailed,

--- a/packages/sdk-core/src/fixed-point-number.ts
+++ b/packages/sdk-core/src/fixed-point-number.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'bignumber.js';
-import { isNumber } from 'lodash';
+import isNumber from 'lodash/isNumber.js';
 
 /**
  * @constant

--- a/packages/sdk-payment/src/Payment.ts
+++ b/packages/sdk-payment/src/Payment.ts
@@ -2,7 +2,7 @@ import { Wallet } from '@acala-network/sdk';
 import { AggregateDex } from '@acala-network/sdk-swap';
 import { PaymentConfig, PaymentMethod, PaymentMethodTypes, Tx } from './types.js';
 import { AnyApi, Token } from '@acala-network/sdk-core';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty.js';
 import { toPromise } from './utils/index.js';
 import { Storages, createStorages } from './storage.js';
 import { NotReady } from './error.js';


### PR DESCRIPTION
fix
```
SyntaxError: Named export 'isArray' not found. The requested module 'lodash' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'lodash';
const { isArray } = pkg;
```