### PR TITLE
Fix esm

### DIFF
--- a/packages/sdk-core/src/converter.ts
+++ b/packages/sdk-core/src/converter.ts
@@ -1,5 +1,5 @@
 import { AcalaPrimitivesCurrencyCurrencyId, AcalaPrimitivesCurrencyTokenSymbol } from '@polkadot/types/lookup';
-import { isArray } from 'lodash';
+import isArray from 'lodash/isArray.js';
 import {
   ConvertToCurrencyIdFailed,
   ConvertToCurrencyNameFailed,

--- a/packages/sdk-core/src/fixed-point-number.ts
+++ b/packages/sdk-core/src/fixed-point-number.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'bignumber.js';
-import { isNumber } from 'lodash';
+import isNumber from 'lodash/isNumber.js';
 
 /**
  * @constant

--- a/packages/sdk-loan/src/loan.ts
+++ b/packages/sdk-loan/src/loan.ts
@@ -5,7 +5,7 @@ import { GlobalLoan, LoanSDKParams, LoanTypes, UserLoan } from './types.js';
 import { map } from 'rxjs/operators';
 import { combineLatest, firstValueFrom, Observable } from 'rxjs';
 import { memoize } from '@polkadot/util';
-import { PriceProviderType } from '@acala-network/sdk/wallet/price-provider/types.js';
+import { PriceProviderType } from '@acala-network/sdk/wallet/price-provider/types';
 import { LoanCalculator } from './loan-calculator.js';
 
 const YEAR_SECONDS = 365 * 24 * 60 * 60; // second of one year

--- a/packages/sdk-loan/src/storages.ts
+++ b/packages/sdk-loan/src/storages.ts
@@ -1,4 +1,4 @@
-import { Storage } from '@acala-network/sdk/utils/storage/index.js';
+import { Storage } from '@acala-network/sdk/utils/storage/index';
 import { AnyApi, Token } from '@acala-network/sdk-core';
 import {
   AcalaPrimitivesPosition,

--- a/packages/sdk-loan/src/types.ts
+++ b/packages/sdk-loan/src/types.ts
@@ -1,6 +1,6 @@
 import { Wallet } from '@acala-network/sdk';
 import { AnyApi, FixedPointNumber, Token } from '@acala-network/sdk-core';
-import { PriceProviderType } from '@acala-network/sdk/wallet/price-provider/types.js';
+import { PriceProviderType } from '@acala-network/sdk/wallet/price-provider/types';
 
 export interface LoanSDKParams {
   api: AnyApi;

--- a/packages/sdk-payment/src/Payment.ts
+++ b/packages/sdk-payment/src/Payment.ts
@@ -2,7 +2,7 @@ import { Wallet } from '@acala-network/sdk';
 import { AggregateDex } from '@acala-network/sdk-swap';
 import { PaymentConfig, PaymentMethod, PaymentMethodTypes, Tx } from './types.js';
 import { AnyApi, Token } from '@acala-network/sdk-core';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty.js';
 import { toPromise } from './utils/index.js';
 import { Storages, createStorages } from './storage.js';
 import { NotReady } from './error.js';

--- a/packages/sdk-payment/src/storage.ts
+++ b/packages/sdk-payment/src/storage.ts
@@ -1,5 +1,5 @@
 import { AnyApi } from '@acala-network/sdk-core';
-import { Storage } from '@acala-network/sdk/utils/storage/index.js';
+import { Storage } from '@acala-network/sdk/utils/storage/index';
 import { AcalaPrimitivesCurrencyCurrencyId } from '@polkadot/types/lookup';
 import { Option, Vec, StorageKey } from '@polkadot/types';
 

--- a/packages/sdk-swap/src/dex-providers/acala/index.ts
+++ b/packages/sdk-swap/src/dex-providers/acala/index.ts
@@ -6,13 +6,13 @@ import {
   Token,
   unzipDexShareName
 } from '@acala-network/sdk-core';
-import { Wallet } from '@acala-network/sdk/wallet/index.js';
+import { Wallet } from '@acala-network/sdk/wallet/index';
 import { AcalaPrimitivesTradingPair, ModuleDexTradingPairStatus } from '@polkadot/types/lookup';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { StorageKey } from '@polkadot/types';
 import { combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { Storage } from '@acala-network/sdk/utils/storage/index.js';
+import { Storage } from '@acala-network/sdk/utils/storage/index';
 import { AmountTooSmall, InsufficientLiquidityError, ParamsNotAcceptableForDexProvider } from '../../errors.js';
 import {
   BaseSwap,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,15 +34,15 @@
       "default": "./dist/esm/*.js"
     },
     "./utils/storage": {
-			"require": "./dist/cjs/utils/storage/index.js",
-			"import": "./dist/esm/utils/storage/index.js",
-			"default": "./dist/esm/utils/storage/index.js"
-		},
+      "require": "./dist/cjs/utils/storage/index.js",
+      "import": "./dist/esm/utils/storage/index.js",
+      "default": "./dist/esm/utils/storage/index.js"
+    },
     "./wallet/wallet": {
-			"require": "./dist/cjs/wallet/wallet.js",
-			"import": "./dist/esm/wallet/wallet.js",
-			"default": "./dist/esm/wallet/wallet.js"
-		}
+      "require": "./dist/cjs/wallet/wallet.js",
+      "import": "./dist/esm/wallet/wallet.js",
+      "default": "./dist/esm/wallet/wallet.js"
+    }
   },
   "repository": "https://github.com/AcalaNetwork/acala.js.git",
   "bugs": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,7 +32,17 @@
       "require": "./dist/cjs/*.js",
       "import": "./dist/esm/*.js",
       "default": "./dist/esm/*.js"
-    }
+    },
+    "./utils/storage": {
+			"require": "./dist/cjs/utils/storage/index.js",
+			"import": "./dist/esm/utils/storage/index.js",
+			"default": "./dist/esm/utils/storage/index.js"
+		},
+    "./wallet/wallet": {
+			"require": "./dist/cjs/wallet/wallet.js",
+			"import": "./dist/esm/wallet/wallet.js",
+			"default": "./dist/esm/wallet/wallet.js"
+		}
   },
   "repository": "https://github.com/AcalaNetwork/acala.js.git",
   "bugs": {

--- a/packages/sdk/src/wallet/balance-adapter/erc20-adapter.ts
+++ b/packages/sdk/src/wallet/balance-adapter/erc20-adapter.ts
@@ -7,7 +7,7 @@ import { from, Observable, Subject } from 'rxjs';
 import { filter, finalize, shareReplay } from 'rxjs/operators';
 import { BalanceData } from '../types.js';
 import { AnyFunction } from '@polkadot/types/types';
-import { NotERC20TokenName } from '@acala-network/sdk-core/errors.js';
+import { NotERC20TokenName } from '@acala-network/sdk-core/errors';
 
 export class ERC20Adapter {
   private provider: EvmRpcProvider;

--- a/packages/sdk/src/wallet/token-provider/acala.ts
+++ b/packages/sdk/src/wallet/token-provider/acala.ts
@@ -12,8 +12,8 @@ import { filter, map, shareReplay, take } from 'rxjs/operators';
 import { TokenProvider, TokenProviderConfigs } from './type.js';
 import { Storage } from '../../utils/storage/index.js';
 import { createTokenList } from './create-token-list.js';
-import { ChainType } from '@acala-network/sdk/types';
-import { getChainType } from '@acala-network/sdk/utils/get-chain-type';
+import { ChainType } from '../../types.js';
+import { getChainType } from '../../utils/get-chain-type.js';
 import { TokenRecord } from '../types.js';
 import { CurrencyNotFound } from '../errors.js';
 

--- a/packages/sdk/src/wallet/token-provider/acala.ts
+++ b/packages/sdk/src/wallet/token-provider/acala.ts
@@ -12,8 +12,8 @@ import { filter, map, shareReplay, take } from 'rxjs/operators';
 import { TokenProvider, TokenProviderConfigs } from './type.js';
 import { Storage } from '../../utils/storage/index.js';
 import { createTokenList } from './create-token-list.js';
-import { ChainType } from '@acala-network/sdk/types.js';
-import { getChainType } from '@acala-network/sdk/utils/get-chain-type.js';
+import { ChainType } from '@acala-network/sdk/types';
+import { getChainType } from '@acala-network/sdk/utils/get-chain-type';
 import { TokenRecord } from '../types.js';
 import { CurrencyNotFound } from '../errors.js';
 

--- a/packages/wormhole-portal/src/wormhole-portal.ts
+++ b/packages/wormhole-portal/src/wormhole-portal.ts
@@ -17,7 +17,7 @@ import {
 
 import { combineLatest, firstValueFrom, from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BaseSDK } from '@acala-network/sdk/types.js';
+import { BaseSDK } from '@acala-network/sdk/types';
 import { SupportChain } from './consts/index.js';
 import {
   ConvertAssetsShouldNotEqual,


### PR DESCRIPTION
fix esm error
```
SyntaxError: Named export 'isNumber' not found. The requested module 'lodash' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'lodash';
const { isNumber } = pkg;
```

```
Error: Cannot find module 'e2e-tests/node_modules/@acala-network/sdk/dist/esm/utils/get-chain-type.js.js' imported from e2e-tests/node_modules/@acala-network/sdk/dist/esm/wallet/token-provider/acala.js
```